### PR TITLE
Cahnge utils import path

### DIFF
--- a/gookmark.go
+++ b/gookmark.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"./utils"
+  "github.com/nocd5/gookmark/utils"
 	"fmt"
 	"os"
 


### PR DESCRIPTION
go install出来なかったため修正PRを送りました。
$GOPATH下では相対パスが効かないため、importの際に"github.com~"の指定に変更しておきました。
